### PR TITLE
Add PHP>=5.4 requirement to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         }
     ],
     "require": {
+        "php": ">=5.4.0",
         "silex/silex": "~1.0"
     },
     "autoload": {


### PR DESCRIPTION
Since the code is using short array syntax, it won't work in PHP 5.3.
