### PR TITLE
Assets path

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ In addition to this you will need to register the service in your Silex app like
 $app->register(new SwaggerUI\Silex\Provider\SwaggerUIServiceProvider(), array(
     'swaggerui.path'       => '/v1/swagger',
     'swaggerui.apiDocPath' => '/v1/docs'
+    'swaggerui.assetsPath' => '/my-path-to-assets'
 ));
 ```
 
 This will result in the SwaggerUI interface being available at */v1/swagger* under you Silex application root. The `swaggerui.apiDovPath` config option specifies the URL/path to the swagger doc files.
-
+You must want choose a specific path for static assets, if you want this, you will need copy the public folder from this project to destination that you want.
+ 
 ## Known issues
 The Swagger UI is pretty slow right now due to the fact that static resources are served _through_ a Silex controller and no cache is in place (yet). I'll try to fix this soon.
 

--- a/src/SwaggerUI/Silex/Provider/SwaggerUIServiceProvider.php
+++ b/src/SwaggerUI/Silex/Provider/SwaggerUIServiceProvider.php
@@ -26,7 +26,7 @@ class SwaggerUIServiceProvider implements ServiceProviderInterface
         $app->get($app['swaggerui.path'], function(Request $request) use ($app) {
             return str_replace(
                 array('{{swaggerui-root}}', '{{swagger-docs}}'),
-                array($request->getBasePath() . $app['swaggerui.assetspath'], $request->getBasePath() . $app['swaggerui.apiDocPath']),
+                array($request->getBasePath() . $app['swaggerui.assetsPath'], $request->getBasePath() . $app['swaggerui.apiDocPath']),
                 file_get_contents(__DIR__ . '/../../../../public/index.html')
             );
         });

--- a/src/SwaggerUI/Silex/Provider/SwaggerUIServiceProvider.php
+++ b/src/SwaggerUI/Silex/Provider/SwaggerUIServiceProvider.php
@@ -26,7 +26,7 @@ class SwaggerUIServiceProvider implements ServiceProviderInterface
         $app->get($app['swaggerui.path'], function(Request $request) use ($app) {
             return str_replace(
                 array('{{swaggerui-root}}', '{{swagger-docs}}'),
-                array($request->getBasePath() . $app['swaggerui.path'], $request->getBasePath() . $app['swaggerui.apiDocPath']),
+                array($request->getBasePath() . $app['swaggerui.assetspath'], $request->getBasePath() . $app['swaggerui.apiDocPath']),
                 file_get_contents(__DIR__ . '/../../../../public/index.html')
             );
         });


### PR DESCRIPTION
Hi,

I had problems with the assets files, so I did a fork and did some changes on the registration loader.
Every time that I tried access the UI by my browser I caught 404 errors for static files. I was following the exact instructions that you have put on the README file. So, if you explain to me why these things were happened I will be glad.

Thank you
